### PR TITLE
identifier example structure

### DIFF
--- a/Examples/polar_data_schema_sample.json
+++ b/Examples/polar_data_schema_sample.json
@@ -1,7 +1,6 @@
 {
     "@context": {
         "@vocab": "http://schema.org/",
-        "datacite": "http://purl.org/spar/datacite/",
         "dbpedia": "http://dbpedia.org/resource/"
     },
     "@type": "Dataset",

--- a/Examples/polar_data_schema_sample.json
+++ b/Examples/polar_data_schema_sample.json
@@ -19,16 +19,11 @@
     ],
     "license": "https://spdx.org/licenses/ODbL-1.0.html",
     "identifier": {
-        "@type": [
-            "PropertyValue",
-            "datacite:ResourceIdentifier"
-        ],
-        "datacite:usesIdentifierScheme": {
-            "@id": "datacite:doi"
-        },
-        "propertyID": "DOI",
-        "url": "https://doi.org/10.0000/0000/plr-stf.123456",
-        "value": "10.0000/0000/plr-stf.123456"
+        "@id": "doi:10.0000/0000/plr-stf.123456",
+        "@type": "PropertyValue",
+        "propertyID": "https://registry.identifiers.org/registry/doi",
+        "value": "doi:10.0000/0000/plr-stf.123456",
+        "url": "https://doi.org/10.0000/0000/plr-stf.123456"
     },
     "spatialCoverage": {
         "@type": "Place",


### PR DESCRIPTION
The current example identifier structure does not follow the current guidance from Science on Schema.org (SOSO) for [representing identifiers](https://github.com/ESIPFed/science-on-schema.org/blob/master/guides/Dataset.md#identifier). This PR requests changes that simplify the example document and bring it in line with what is proposed by SOSO. It eliminates use of the DataCite namespace in favor of using the more comprehensive identifiers.org URIs for identifier types, which is what SOSO recommends. Thanks for considering this change.